### PR TITLE
Validate emails

### DIFF
--- a/resources/en_US.clj
+++ b/resources/en_US.clj
@@ -3,6 +3,7 @@
   {
     :not-found "No election with ID %d found."
     :new-voters-registered "%d new voter(s) registered."
+    :invalid-voter-mails "%d new voter(s) have invalid emails"
     :voter-registration-failed "Voter registration failed"
     :create "Create election"
     :name "Election name"

--- a/resources/en_US.clj
+++ b/resources/en_US.clj
@@ -3,7 +3,7 @@
   {
     :not-found "No election with ID %d found."
     :new-voters-registered "%d new voter(s) registered."
-    :invalid-voter-mails "%d new voter(s) have invalid emails"
+    :some-voters-registered "%d new voter(s) registered (existing: %d, invalid: %d)"
     :voter-registration-failed "Voter registration failed"
     :create "Create election"
     :name "Election name"

--- a/resources/pt_BR.clj
+++ b/resources/pt_BR.clj
@@ -3,7 +3,7 @@
   {
     :not-found "Eleição com ID %d não foi encontrada."
     :new-voters-registered "%d novo(s) eleitor(es) inscrito(s)."
-    :invalid-voter-mails "%d new voter(s) have invalid emails."
+    :some-voters-registered "%d new voter(s) registered (existing: %d, invalid: %d)"
     :voter-registration-failed "Inscrição de eleitores falhou"
     :create "Criar eleição"
     :name "Nome da eleição"

--- a/resources/pt_BR.clj
+++ b/resources/pt_BR.clj
@@ -3,6 +3,7 @@
   {
     :not-found "Eleição com ID %d não foi encontrada."
     :new-voters-registered "%d novo(s) eleitor(es) inscrito(s)."
+    :invalid-voter-mails "%d new voter(s) have invalid emails."
     :voter-registration-failed "Inscrição de eleitores falhou"
     :create "Criar eleição"
     :name "Nome da eleição"

--- a/resources/pt_BR.clj
+++ b/resources/pt_BR.clj
@@ -3,7 +3,7 @@
   {
     :not-found "Eleição com ID %d não foi encontrada."
     :new-voters-registered "%d novo(s) eleitor(es) inscrito(s)."
-    :some-voters-registered "%d new voter(s) registered (existing: %d, invalid: %d)"
+    :some-voters-registered "%d novo(s) eleitor(es) inscrito(s) (existentes: %d, inválidos: %d)"
     :voter-registration-failed "Inscrição de eleitores falhou"
     :create "Criar eleição"
     :name "Nome da eleição"

--- a/src/clj/election/controllers/elections.clj
+++ b/src/clj/election/controllers/elections.clj
@@ -63,9 +63,9 @@
 (def email-pattern #"(?:[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*|\"(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21\x23-\x5b\x5d-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])*\")@(?:(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?|\[(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?|[a-z0-9-]*[a-z0-9]:(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21-\x5a\x53-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])+)\])")
 (defn is-valid-email? [value]
   (re-matches email-pattern value))
-(defn get-invalid-mails [voters]
+(defn keep-valid-mails [voters]
   (filter
-    (comp not is-valid-email? second)
+    (comp is-valid-email? second)
     voters))
 
 (defn register-voters [{{election-id :election-id {voters-file :tempfile} :voters} :params {user :user} :session :as request}]
@@ -73,19 +73,28 @@
     response (response/redirect (paths/election-path election-id))]
     (if (auth/can-register-voters? election user)
       (let [voters (voters-from voters-file)
-            invalid-voters (get-invalid-mails voters)]
-        (if (empty? invalid-voters)
-          (let [added-voters-count (voters/register-voters (:id election) voters)]
-            (if added-voters-count
-              (assoc response :flash {:type :notice :message (i18n/t request :elections/new-voters-registered added-voters-count)})
-              (assoc response :flash {:type :error :message (i18n/t request :elections/voter-registration-failed)})
-            ))
-          (assoc 
-            response 
-            :flash 
-            {
-              :type :error 
-              :message (i18n/t request :elections/invalid-voter-mails (count invalid-voters))
+            valid-voters (keep-valid-mails voters)
+            added-voters-count (voters/register-voters (:id election) valid-voters)]
+        (cond
+          ; Failure during the process
+          (not added-voters-count)
+          (assoc response :flash {:type :error :message (i18n/t request :elections/voter-registration-failed)})
+          ; all mails where added
+          (= added-voters-count (count voters))
+          (assoc response :flash {:type :notice :message (i18n/t request :elections/new-voters-registered added-voters-count)})
+          ; mails were added, but some were already present and others were invalid
+          :else
+          (assoc
+            response
+            :flash {
+              :type :notice
+              :message (i18n/t
+                request
+                :elections/some-voters-registered
+                added-voters-count
+                (- (count valid-voters) added-voters-count)
+                (- (count voters) (count valid-voters))
+              )
             }
           )
         )

--- a/src/clj/election/controllers/elections.clj
+++ b/src/clj/election/controllers/elections.clj
@@ -61,7 +61,7 @@
 
 ; RegExp from http://emailregex.com/
 (def email-pattern #"(?:[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*|\"(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21\x23-\x5b\x5d-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])*\")@(?:(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?|\[(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?|[a-z0-9-]*[a-z0-9]:(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21-\x5a\x53-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])+)\])")
-(def is-valid-email? [value]
+(defn is-valid-email? [value]
   (re-matches email-pattern value))
 (defn get-invalid-mails [voters]
   (filter
@@ -74,7 +74,7 @@
     (if (auth/can-register-voters? election user)
       (let [voters (voters-from voters-file)
             invalid-voters (get-invalid-mails voters)]
-        (if (empty? invalid-voters))
+        (if (empty? invalid-voters)
           (let [added-voters-count (voters/register-voters (:id election) voters)]
             (if added-voters-count
               (assoc response :flash {:type :notice :message (i18n/t request :elections/new-voters-registered added-voters-count)})
@@ -85,7 +85,11 @@
             :flash 
             {
               :type :error 
-              :message (i18n/t request :elections/invalid-voter-mails (count invalid-voters))}))
+              :message (i18n/t request :elections/invalid-voter-mails (count invalid-voters))
+            }
+          )
+        )
+      )
       (assoc response :flash {:type :error :message (i18n/t request :forbidden)})
     )
   )

--- a/test/clj/election/controllers/elections_test.clj
+++ b/test/clj/election/controllers/elections_test.clj
@@ -1,0 +1,10 @@
+(ns election.controllers.elections-test
+  (:use clojure.test)
+  (:require
+    [election.controllers.elections :as e]))
+
+(deftest email-validation
+  (testing "accepts gmail email"
+    (let [result (e/is-valid-email? "someone@gmail.com")]
+      (is (= true result))
+    )))

--- a/test/clj/election/controllers/elections_test.clj
+++ b/test/clj/election/controllers/elections_test.clj
@@ -3,7 +3,7 @@
   (:require
     [election.controllers.elections :as e]))
 
-(deftest email-validation
+(deftest basic-email-validation
   (testing "accepts gmail email"
     (let [result (e/is-valid-email? "someone@gmail.com")]
       (is result)
@@ -19,6 +19,10 @@
       (is result)
     )
   )
+  (testing "accepts organization emails"
+    (let [result (e/is-valid-email? "me@agilealliancebrazil.org.br")]
+      (is result))
+  )
   (testing "rejects email without @"
     (let [result (e/is-valid-email? "agmail.com")]
       (is (not result))
@@ -30,23 +34,94 @@
     )
   )
 )
+(deftest advanced-email-validation
+  ; From this website, referencing some strange emails:
+  ; https://codefool.tumblr.com/post/15288874550/list-of-valid-and-invalid-email-addresses
+  ; Some of the listed emails are valid but not supported.
+  ; However, they represent very unusual cases, that we won't try to support
 
-(deftest invalid-mail-filtering
-  (testing "returns empty list if all is good"
+  ; Exceptions:
+  ; Valid emails not supported
+  ;  - "“email”@example.com"
+  ;  - "much.“more\ unusual”@example.com"
+  ;  - "very.unusual.“@”.unusual.com@example.com"
+  ;  - "very.“(),:;<>[]”.VERY.“very@\\ \"very”.unusual@strange.example.com"
+  ; Invalid emails not rejected:
+  ;  - "email@example.web" -> invalid top-level domain
+  ;  - "email@111.222.333.44444" -> invalid ip address
+  (let [emails ["email@example.com"
+                "firstname.lastname@example.com"
+                "email@subdomain.example.com"
+                "firstname+lastname@example.com"
+                "email@123.123.123.123"
+                "email@[123.123.123.123]"
+                "1234567890@example.com"
+                "email@example-one.com"
+                "_______@example.com"
+                "email@example.name"
+                "email@example.museum"
+                "email@example.co.jp"
+                "firstname-lastname@example.com"]]
+    (doseq [email emails]
+      (testing (str "accepts common email: {" email "}")
+        (let [result (e/is-valid-email? email)]
+          (is result)
+        )
+      )
+    )
+  )
+
+  (let [emails ["plainaddress"
+                "#@%^%#$@#$@#.com"
+                "@example.com"
+                "Joe Smith <email@example.com>"
+                "email.example.com"
+                "email@example@example.com"
+                ".email@example.com"
+                "email.@example.com"
+                "email..email@example.com"
+                "あいうえお@example.com"
+                "email@example.com (Joe Smith)"
+                "email@example"
+                "email@-example.com"
+                "email@example..com"
+                "Abc..123@example.com"]]
+    (doseq [email emails]
+      (testing (str "accepts invalid email: {" email "}")
+        (let [result (e/is-valid-email? email)]
+          (is (not result))
+        )
+      )
+    )
+  )
+  (let [emails ["“(),:;<>[\\]@example.com"
+                "just\"not\"right@example.com"
+                "this\\ is\"really\"not\\allowed@example.com"]]
+    (doseq [email emails]
+      (testing (str "accepts uncommon invalid email: {" email "}")
+        (let [result (e/is-valid-email? email)]
+          (is (not result))
+        )
+      )
+    )
+  )
+)
+
+(deftest valid-mail-filtering
+  (testing "returns the complete list if all is good"
     (let [voters [[1 "a@gmail.com" "a"]
                   [2 "b@outlook.com" "b"]
                   [3 "c@protonmail.com", "c"]]
-          invalid (e/get-invalid-mails voters)]
-      (is (empty? invalid))
+          valid (e/keep-valid-mails voters)]
+      (is (= voters valid))
     )
   )
-  (testing "returns the wrong voters if any"
+  (testing "returns the valid voters if any"
     (let [voters [[1 "bad.mail.com"]
                   [2 "b@outlook.com"]
                   [3 "not@yahoo"]]
-          invalid (e/get-invalid-mails voters)]
-      (is (= invalid [[1 "bad.mail.com"]
-                      [3 "not@yahoo"]]))
+          invalid (e/keep-valid-mails voters)]
+      (is (= invalid [[2 "b@outlook.com"]]))
     )
   )
 )

--- a/test/clj/election/controllers/elections_test.clj
+++ b/test/clj/election/controllers/elections_test.clj
@@ -6,5 +6,47 @@
 (deftest email-validation
   (testing "accepts gmail email"
     (let [result (e/is-valid-email? "someone@gmail.com")]
-      (is (= true result))
-    )))
+      (is result)
+    )
+  )
+  (testing "accepts email with dots"
+    (let [result (e/is-valid-email? "a.b.c@yahoo.com")]
+      (is result)
+    )
+  )
+  (testing "accepts special gmail with +"
+    (let [result (e/is-valid-email? "some+one@gmail.com")]
+      (is result)
+    )
+  )
+  (testing "rejects email without @"
+    (let [result (e/is-valid-email? "agmail.com")]
+      (is (not result))
+    )
+  )
+  (testing "rejects email without domain"
+    (let [result (e/is-valid-email? "some@gmail")]
+      (is (not result))
+    )
+  )
+)
+
+(deftest invalid-mail-filtering
+  (testing "returns empty list if all is good"
+    (let [voters [[1 "a@gmail.com" "a"]
+                  [2 "b@outlook.com" "b"]
+                  [3 "c@protonmail.com", "c"]]
+          invalid (e/get-invalid-mails voters)]
+      (is (empty? invalid))
+    )
+  )
+  (testing "returns the wrong voters if any"
+    (let [voters [[1 "bad.mail.com"]
+                  [2 "b@outlook.com"]
+                  [3 "not@yahoo"]]
+          invalid (e/get-invalid-mails voters)]
+      (is (= invalid [[1 "bad.mail.com"]
+                      [3 "not@yahoo"]]))
+    )
+  )
+)


### PR DESCRIPTION
I added some validation when registering voters. This PR checks that the list of voters does not contain any voter with an invalid email.
Otherwise, the list of invalid voters is returned and the process of registration is aborted.

As there were no tests on the controller, I haven't check the operation through the request. But there are unit tests on the regexp.

Closes: #17.