### PR TITLE
Validate the email of new candidates.

### DIFF
--- a/resources/en_US.clj
+++ b/resources/en_US.clj
@@ -29,6 +29,7 @@
     :motivation "Motivation"
     :region "Region"
     :minibio "Mini-bio"
+    :invalid-email "Invalid email"
   }
   :votes
   {

--- a/resources/pt_BR.clj
+++ b/resources/pt_BR.clj
@@ -29,6 +29,7 @@
     :motivation "Motivação"
     :region "Região"
     :minibio "Minibio"
+    :invalid-email "Invalid email"
   }
   :votes
   {

--- a/resources/pt_BR.clj
+++ b/resources/pt_BR.clj
@@ -29,7 +29,7 @@
     :motivation "Motivação"
     :region "Região"
     :minibio "Minibio"
-    :invalid-email "Invalid email"
+    :invalid-email "Email inválido"
   }
   :votes
   {


### PR DESCRIPTION
Reading again #17, I see that I omitted candidate email validation in PR #20.
This PR adds validation for that specific part.

Once again, the translation in Brazilian is missing. I prefer having a native speaker giving me the translation that using a random translation tool.

Closes: #17 