### PR TITLE
Detail vote error.

### DIFF
--- a/resources/en_US.clj
+++ b/resources/en_US.clj
@@ -40,13 +40,14 @@
     :instructions "Please select %d candidate(s) towards which you will cast your vote and press the 'Place Vote' button."
     :place "Place Vote"
     :used-token "Token already used"
-    :not-accepting-votes "Not currently in voting period"
     :recorded "Vote recorded! Thank you."
     :invalid "Invalid vote. Please ensure you selected the right amount of candidates."
     :confirm "Votes cannot be changed once cast. Are you sure you want to cast your vote?"
     :voter-count "Total voter count"
     :votes-count "Total votes to receive"
     :casted-votes-count "Total votes received"
+    :not-started "Election has not started yet."
+    :too-late "Election vote time is over."
   }
   :session
   {

--- a/resources/pt_BR.clj
+++ b/resources/pt_BR.clj
@@ -40,13 +40,14 @@
     :instructions "Por favor, selecione %d candidato(a) a favor do(a) qual seu voto será contabilizado e pressione o botão 'Votar'."
     :place "Votar"
     :used-token "Seu token já foi utilizado"
-    :not-accepting-votes "Essa eleição não está em período de votação"
     :recorded "Voto contabilizado! Obrigado."
     :invalid "Voto inválido. Por favor, verifique que selecionou a quantidade correta de candidatos."
     :confirm "Votos não podem ser alterados uma vez que forem enviados. Você tem certeza que deseja enviar seu voto?"
     :voter-count "Total de eleitores"
     :votes-count "Total de votos a receber"
     :casted-votes-count "Total de votos recebidos"
+    :not-started "Election has not started yet."
+    :too-late "Election vote time is over."
   }
   :session
   {

--- a/resources/pt_BR.clj
+++ b/resources/pt_BR.clj
@@ -46,8 +46,8 @@
     :voter-count "Total de eleitores"
     :votes-count "Total de votos a receber"
     :casted-votes-count "Total de votos recebidos"
-    :not-started "Election has not started yet."
-    :too-late "Election vote time is over."
+    :not-started "A eleição ainda não começou."
+    :too-late "A eleição já encerrou."
   }
   :session
   {

--- a/src/clj/election/controllers/votes.clj
+++ b/src/clj/election/controllers/votes.clj
@@ -30,7 +30,7 @@
   )
 )
 
-(defn- build-flash [request election token]
+(defn- build-flash-error [request election token]
   {
     :type :error
     :message
@@ -53,7 +53,7 @@
       )
       (->
         (redirect (paths/election-path (:id election)))
-        (assoc :flash (build-flash request election token))
+        (assoc :flash (build-flash-error request election token))
       )
     )
   )

--- a/test/clj/election/controllers/votes_test.clj
+++ b/test/clj/election/controllers/votes_test.clj
@@ -8,10 +8,41 @@
   )
 )
 
+(def past-date (-> (t/now) (t/minus (t/months 1)) (c/to-sql-time)))
+(def future-date (-> (t/now) (t/plus (t/months 1)) (c/to-sql-time)))
+
+(deftest check-election-start-detection
+  (let [f #'v/check-election-start]
+    (testing "detects dates past the election start"
+      (let [election {:startdate past-date}]
+        (= (f election) :after)
+      )
+    )
+    (testing "detects dates before the election start"
+      (let [election {:startdate future-date}]
+        (= (f election) :before)
+      )
+    )
+  )
+)
+
+(deftest check-election-end-detection
+  (let [f #'v/check-election-end]
+    (testing "detects dates past the election end"
+      (let [election {:enddate past-date}]
+        (= (f election) :after)
+      )
+    )
+    (testing "detects dates before the election end"
+      (let [election {:enddate future-date}]
+        (= (f election) :before)
+      )
+    )
+  )
+)
+
 (deftest check-error-flash-message
   (let [f #'v/build-flash-error
-        past-date (-> (t/now) (t/minus (t/months 2)) (c/to-sql-time))
-        future-date (-> (t/now) (t/plus (t/months 1)) (c/to-sql-time))
         request {:locale :en-US}]
     (testing "generates a message for early votes"
       (let [so-future-date (-> (t/now) (t/plus (t/years 1)) (c/to-sql-time))

--- a/test/clj/election/controllers/votes_test.clj
+++ b/test/clj/election/controllers/votes_test.clj
@@ -1,0 +1,14 @@
+(ns election.controllers.votes-test
+  (:use clojure.test)
+  (:require
+    [election.controllers.votes :as v]
+  )
+)
+
+(deftest check-error-flash-message
+	(let [f #'v/build-flash]
+		(testing "??"
+			(is (= false true))
+		)
+	)
+)

--- a/test/clj/election/controllers/votes_test.clj
+++ b/test/clj/election/controllers/votes_test.clj
@@ -2,13 +2,80 @@
   (:use clojure.test)
   (:require
     [election.controllers.votes :as v]
+    [clj-time.core :as t]
+    [clj-time.coerce :as c]
+    [election.i18n.messages :as i18n]
   )
 )
 
+
+; (defn- check-election-start [election]
+;   (if (t/after? (t/now) (c/from-sql-time (:startdate election)))
+;     :after
+;     :before))
+; (defn- check-election-end [election]
+;   (if (t/before? (t/now) (c/from-sql-time (:enddate election)))
+;     :before
+;     :after))
+
+(def past-date (-> (t/now) (t/minus (t/months 1)) (c/to-sql-time)))
+(def future-date (-> (t/now) (t/plus (t/months 1)) (c/to-sql-time)))
+
+(deftest check-election-start-detection
+	(let [f #'v/check-election-start]
+		(testing "detects dates past the election start"
+			(let [election {:startdate past-date}]
+				(= (f election) :after)
+			)
+		)
+		(testing "detects dates before the election start"
+			(let [election {:startdate future-date}]
+				(= (f election) :before)
+			)
+		)
+	)
+)
+
+(deftest check-election-end-detection
+	(let [f #'v/check-election-end]
+		(testing "detects dates past the election end"
+			(let [election {:enddate past-date}]
+				(= (f election) :after)
+			)
+		)
+		(testing "detects dates before the election end"
+			(let [election {:enddate future-date}]
+				(= (f election) :before)
+			)
+		)
+	)
+)
+
 (deftest check-error-flash-message
-	(let [f #'v/build-flash]
-		(testing "??"
-			(is (= false true))
+	(let [f #'v/build-flash-error
+				request {:locale :en-US}]
+		(testing "generates a message for early votes"
+			(let [so-future-date (-> (t/now) (t/plus (t/years 1)) (c/to-sql-time))
+						election {:startdate future-date :enddate so-future-date}
+						flash (f request election nil)]
+				(is (= (:type flash) :error))
+				(is (= (:message flash) (i18n/t request :votes/not-started)))
+			)
+		)
+		(testing "generates a message for late votes"
+			(let [very-old-date (-> (t/now) (t/minus (t/years 1)) (c/to-sql-time))
+						election {:startdate very-old-date :enddate past-date}
+						flash (f request election nil)]
+				(is (= (:type flash) :error))
+				(is (= (:message flash) (i18n/t request :votes/too-late)))
+			)
+		)
+		(testing "generates a message for invalid token"
+			(let [election {:startdate past-date :enddate future-date}
+						flash (f request election nil)]
+				(is (= (:type flash) :error))
+				(is (= (:message flash) (i18n/t request :votes/used-token)))
+			)
 		)
 	)
 )

--- a/test/clj/election/controllers/votes_test.clj
+++ b/test/clj/election/controllers/votes_test.clj
@@ -8,74 +8,34 @@
   )
 )
 
-
-; (defn- check-election-start [election]
-;   (if (t/after? (t/now) (c/from-sql-time (:startdate election)))
-;     :after
-;     :before))
-; (defn- check-election-end [election]
-;   (if (t/before? (t/now) (c/from-sql-time (:enddate election)))
-;     :before
-;     :after))
-
-(def past-date (-> (t/now) (t/minus (t/months 1)) (c/to-sql-time)))
-(def future-date (-> (t/now) (t/plus (t/months 1)) (c/to-sql-time)))
-
-(deftest check-election-start-detection
-	(let [f #'v/check-election-start]
-		(testing "detects dates past the election start"
-			(let [election {:startdate past-date}]
-				(= (f election) :after)
-			)
-		)
-		(testing "detects dates before the election start"
-			(let [election {:startdate future-date}]
-				(= (f election) :before)
-			)
-		)
-	)
-)
-
-(deftest check-election-end-detection
-	(let [f #'v/check-election-end]
-		(testing "detects dates past the election end"
-			(let [election {:enddate past-date}]
-				(= (f election) :after)
-			)
-		)
-		(testing "detects dates before the election end"
-			(let [election {:enddate future-date}]
-				(= (f election) :before)
-			)
-		)
-	)
-)
-
 (deftest check-error-flash-message
-	(let [f #'v/build-flash-error
-				request {:locale :en-US}]
-		(testing "generates a message for early votes"
-			(let [so-future-date (-> (t/now) (t/plus (t/years 1)) (c/to-sql-time))
-						election {:startdate future-date :enddate so-future-date}
-						flash (f request election nil)]
-				(is (= (:type flash) :error))
-				(is (= (:message flash) (i18n/t request :votes/not-started)))
-			)
-		)
-		(testing "generates a message for late votes"
-			(let [very-old-date (-> (t/now) (t/minus (t/years 1)) (c/to-sql-time))
-						election {:startdate very-old-date :enddate past-date}
-						flash (f request election nil)]
-				(is (= (:type flash) :error))
-				(is (= (:message flash) (i18n/t request :votes/too-late)))
-			)
-		)
-		(testing "generates a message for invalid token"
-			(let [election {:startdate past-date :enddate future-date}
-						flash (f request election nil)]
-				(is (= (:type flash) :error))
-				(is (= (:message flash) (i18n/t request :votes/used-token)))
-			)
-		)
-	)
+  (let [f #'v/build-flash-error
+        past-date (-> (t/now) (t/minus (t/months 2)) (c/to-sql-time))
+        future-date (-> (t/now) (t/plus (t/months 1)) (c/to-sql-time))
+        request {:locale :en-US}]
+    (testing "generates a message for early votes"
+      (let [so-future-date (-> (t/now) (t/plus (t/years 1)) (c/to-sql-time))
+            election {:startdate future-date :enddate so-future-date}
+            flash (f request election nil)]
+        (is (= (:type flash) :error))
+        (is (= (:message flash) (i18n/t request :votes/not-started)))
+      )
+    )
+    (testing "generates a message for late votes"
+      (let [very-old-date (-> (t/now) (t/minus (t/years 1)) (c/to-sql-time))
+            election {:startdate very-old-date :enddate past-date}
+            flash (f request election nil)]
+        (is (= (:type flash) :error))
+        (is (= (:message flash) (i18n/t request :votes/too-late)))
+      )
+    )
+    (testing "generates a message for invalid token"
+      (let [election {:startdate past-date :enddate future-date}
+            flash (f request election nil)]
+        (is (= (:type flash) :error))
+        (is (= (:message flash) (i18n/t request :votes/used-token)))
+      )
+    )
+  )
 )
+


### PR DESCRIPTION
This PR provides an improved version of the flash error message generate when a vote is submitted before the election start or after the election end.

Again, the messages are not translated in Brazilian.

Closes: #5  